### PR TITLE
Foreslår innføring av inline-classes for å enkelt kunne lage tiny types

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import com.expediagroup.graphql.plugin.gradle.graphql
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     // Apply the Kotlin JVM plugin to add support for Kotlin on the JVM.
@@ -13,8 +14,9 @@ plugins {
     application
 }
 
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+tasks.withType<KotlinCompile> {
     kotlinOptions.jvmTarget = "13"
+    kotlinOptions.freeCompilerArgs = listOf("-Xinline-classes")
 }
 
 repositories {

--- a/buildSrc/src/main/kotlin/RecommendedVersions.kt
+++ b/buildSrc/src/main/kotlin/RecommendedVersions.kt
@@ -55,7 +55,7 @@ object Kluent {
 }
 
 object Kotlin {
-    const val version = "1.4.30"
+    const val version = "1.4.31"
     private const val groupId = "org.jetbrains.kotlin"
 
     const val reflect = "$groupId:kotlin-reflect:$version"

--- a/src/main/kotlin/no/nav/personbruker/minesaker/api/saf/domain/Dokumentinfo.kt
+++ b/src/main/kotlin/no/nav/personbruker/minesaker/api/saf/domain/Dokumentinfo.kt
@@ -1,7 +1,7 @@
 package no.nav.personbruker.minesaker.api.saf.domain
 
 data class Dokumentinfo(
-    val tittel: String,
-    val filuuid: String,
+    val tittel: Tittel,
+    val filuuid: FilUUID,
     val brukerHarTilgang: Boolean
 )

--- a/src/main/kotlin/no/nav/personbruker/minesaker/api/saf/domain/Journalpost.kt
+++ b/src/main/kotlin/no/nav/personbruker/minesaker/api/saf/domain/Journalpost.kt
@@ -1,8 +1,8 @@
 package no.nav.personbruker.minesaker.api.saf.domain
 
 data class Journalpost(
-    val tittel: String,
-    val journalpostId: String,
+    val tittel: Tittel,
+    val journalpostId: JournalpostId,
     val journalposttype: Journalposttype,
     val avsenderMottaker: AvsenderMottaker,
     val relevanteDatoer: List<RelevantDato>,

--- a/src/main/kotlin/no/nav/personbruker/minesaker/api/saf/domain/Sakstema.kt
+++ b/src/main/kotlin/no/nav/personbruker/minesaker/api/saf/domain/Sakstema.kt
@@ -1,7 +1,7 @@
 package no.nav.personbruker.minesaker.api.saf.domain
 
 data class Sakstema(
-    val navn: String,
+    val navn: Navn,
     val kode: String,
     val journalposter : List<Journalpost> = emptyList()
 )

--- a/src/main/kotlin/no/nav/personbruker/minesaker/api/saf/domain/inlineClasses.kt
+++ b/src/main/kotlin/no/nav/personbruker/minesaker/api/saf/domain/inlineClasses.kt
@@ -1,0 +1,9 @@
+package no.nav.personbruker.minesaker.api.saf.domain
+
+inline class Tittel(val value: String)
+
+inline class Navn(val value: String)
+
+inline class FilUUID(val value: String)
+
+inline class JournalpostId(val value: String)

--- a/src/main/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/transformers/DokumentInfoTransformer.kt
+++ b/src/main/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/transformers/DokumentInfoTransformer.kt
@@ -3,6 +3,8 @@ package no.nav.personbruker.minesaker.api.saf.journalposter.transformers
 import no.nav.dokument.saf.selvbetjening.generated.dto.HentJournalposter
 import no.nav.personbruker.minesaker.api.common.exception.MissingFieldException
 import no.nav.personbruker.minesaker.api.saf.domain.Dokumentinfo
+import no.nav.personbruker.minesaker.api.saf.domain.FilUUID
+import no.nav.personbruker.minesaker.api.saf.domain.Tittel
 
 object DokumentInfoTransformer {
 
@@ -29,8 +31,8 @@ object DokumentInfoTransformer {
         external: HentJournalposter.DokumentInfo,
         externalVariant: HentJournalposter.Dokumentvariant
     ) = Dokumentinfo(
-        external.tittel ?: throw MissingFieldException("tittel"),
-        externalVariant.filuuid ?: throw MissingFieldException("filuuid"),
+        Tittel(external.tittel ?: throw MissingFieldException("tittel")),
+        FilUUID(externalVariant.filuuid ?: throw MissingFieldException("filuuid")),
         externalVariant.brukerHarTilgang == true
     )
 

--- a/src/main/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/transformers/JournalpostTransformer.kt
+++ b/src/main/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/transformers/JournalpostTransformer.kt
@@ -3,6 +3,8 @@ package no.nav.personbruker.minesaker.api.saf.journalposter.transformers
 import no.nav.dokument.saf.selvbetjening.generated.dto.HentJournalposter
 import no.nav.personbruker.minesaker.api.common.exception.MissingFieldException
 import no.nav.personbruker.minesaker.api.saf.domain.Journalpost
+import no.nav.personbruker.minesaker.api.saf.domain.JournalpostId
+import no.nav.personbruker.minesaker.api.saf.domain.Tittel
 
 object JournalpostTransformer {
 
@@ -15,8 +17,8 @@ object JournalpostTransformer {
 }
 
 fun HentJournalposter.Journalpost.toInternal() = Journalpost(
-    tittel ?: throw MissingFieldException("tittel"),
-    journalpostId,
+    Tittel(tittel ?: throw MissingFieldException("tittel")),
+    JournalpostId(journalpostId),
     journalposttype?.toInternal() ?: throw MissingFieldException("journalposttype"),
     avsenderMottaker?.toInternal() ?: throw MissingFieldException("avsenderMottaker"),
     relevanteDatoer.filterNotNull().map { external -> external.toInternal() },

--- a/src/main/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/transformers/SakstemaTransformer.kt
+++ b/src/main/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/transformers/SakstemaTransformer.kt
@@ -2,10 +2,11 @@ package no.nav.personbruker.minesaker.api.saf.journalposter.transformers
 
 import no.nav.dokument.saf.selvbetjening.generated.dto.HentJournalposter
 import no.nav.personbruker.minesaker.api.common.exception.MissingFieldException
+import no.nav.personbruker.minesaker.api.saf.domain.Navn
 import no.nav.personbruker.minesaker.api.saf.domain.Sakstema
 
 fun HentJournalposter.Sakstema.toInternal() = Sakstema(
-    navn ?: throw MissingFieldException("navn"),
+    Navn(navn ?: throw MissingFieldException("navn")),
     kode ?: throw MissingFieldException("kode"),
     journalposter.filterNotNull().map { external -> external.toInternal() }
 )

--- a/src/main/kotlin/no/nav/personbruker/minesaker/api/saf/sakstemaer/HentSakstemaerTransformer.kt
+++ b/src/main/kotlin/no/nav/personbruker/minesaker/api/saf/sakstemaer/HentSakstemaerTransformer.kt
@@ -2,6 +2,7 @@ package no.nav.personbruker.minesaker.api.saf.sakstemaer
 
 import no.nav.dokument.saf.selvbetjening.generated.dto.HentSakstemaer
 import no.nav.personbruker.minesaker.api.common.exception.MissingFieldException
+import no.nav.personbruker.minesaker.api.saf.domain.Navn
 import no.nav.personbruker.minesaker.api.saf.domain.Sakstema
 
 object HentSakstemaerTransformer {
@@ -16,7 +17,7 @@ object HentSakstemaerTransformer {
 
 fun HentSakstemaer.Sakstema.toInternal(): Sakstema {
     return Sakstema(
-        navn ?: throw MissingFieldException("navn"),
+        Navn(navn ?: throw MissingFieldException("navn")),
         kode ?: throw MissingFieldException("kode")
     )
 }

--- a/src/test/kotlin/no/nav/personbruker/minesaker/api/saf/SafConsumerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/minesaker/api/saf/SafConsumerTest.kt
@@ -45,7 +45,7 @@ internal class SafConsumerTest {
         val externalSakstema = externalResponse.data!!.dokumentoversiktSelvbetjening.tema
         internalSakstema.size `should be equal to` externalSakstema.size
         internalSakstema[0] `should be instance of` Sakstema::class
-        internalSakstema[0].navn `should be equal to` externalSakstema[0].navn
+        internalSakstema[0].navn.value `should be equal to` externalSakstema[0].navn
         internalSakstema[0].kode.`should be equal to`(externalSakstema[0].kode)
         internalSakstema `should not be equal to` externalSakstema
     }
@@ -71,7 +71,7 @@ internal class SafConsumerTest {
         val externalSakstema = externalResponse.data!!.dokumentoversiktSelvbetjening.tema
         internalSakstema.size `should be equal to` externalSakstema.size
         internalSakstema[0] `should be instance of` Sakstema::class
-        internalSakstema[0].navn `should be equal to` externalSakstema[0].navn
+        internalSakstema[0].navn.value `should be equal to` externalSakstema[0].navn
         internalSakstema[0].kode `should be equal to` externalSakstema[0].kode
         internalSakstema `should not be equal to` externalSakstema
     }

--- a/src/test/kotlin/no/nav/personbruker/minesaker/api/saf/domain/inlineClassesTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/minesaker/api/saf/domain/inlineClassesTest.kt
@@ -1,0 +1,24 @@
+package no.nav.personbruker.minesaker.api.saf.domain
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.amshove.kluent.`should contain`
+import org.junit.jupiter.api.Test
+
+internal class inlineClassesTest {
+
+    private val objectMapper = jacksonObjectMapper()
+
+    @Test
+    fun `Inline klasser skal ikke generere noe overhead naar det serialiseres til JSON`() {
+        val dokumentinfo = Dokumentinfo(Tittel("Tittelen"), FilUUID("uuiden"), true)
+
+        val dokumentInfoAsJson = objectMapper.writeValueAsString(dokumentinfo)
+
+        println(dokumentInfoAsJson)
+
+        dokumentInfoAsJson `should contain` """"filuuid":"uuiden""""
+        dokumentInfoAsJson `should contain` """"tittel":"Tittelen""""
+        dokumentInfoAsJson `should contain` """"brukerHarTilgang":true"""
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/transformers/DokumentinfoTransformerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/transformers/DokumentinfoTransformerTest.kt
@@ -32,8 +32,8 @@ internal class DokumentinfoTransformerTest {
 
         internals.shouldNotBeEmpty()
         internals.size `should be equal to` 1
-        internals[0].tittel `should be equal to` expectedDokument.tittel
-        internals[0].filuuid `should be equal to` expectedDokumentVariant?.filuuid
+        internals[0].tittel.value `should be equal to` expectedDokument.tittel
+        internals[0].filuuid.value `should be equal to` expectedDokumentVariant?.filuuid
         internals[0].brukerHarTilgang `should be equal to` expectedDokumentVariant?.brukerHarTilgang
     }
 

--- a/src/test/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/transformers/JournalpostTransformerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/transformers/JournalpostTransformerTest.kt
@@ -30,8 +30,8 @@ internal class JournalpostTransformerTest {
         val internal = external.toInternal()
 
         internal.shouldNotBeNull()
-        internal.tittel `should be equal to` external.tittel
-        internal.journalpostId `should be equal to` external.journalpostId
+        internal.tittel.value `should be equal to` external.tittel
+        internal.journalpostId.value `should be equal to` external.journalpostId
 
         internal.arkiverteDokumenter.shouldNotBeEmpty()
         internal.avsenderMottaker.shouldNotBeNull()

--- a/src/test/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/transformers/SakstemaTransformerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/transformers/SakstemaTransformerTest.kt
@@ -13,7 +13,7 @@ internal class SakstemaTransformerTest {
 
         val internal = external.toInternal()
 
-        internal.navn `should be equal to` external.navn
+        internal.navn.value `should be equal to` external.navn
         internal.kode `should be equal to` external.kode
         internal.journalposter.`should not be empty`()
         internal.journalposter.size `should be equal to` 1

--- a/src/test/kotlin/no/nav/personbruker/minesaker/api/saf/sakstemaer/HentSakstemaerTransformerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/minesaker/api/saf/sakstemaer/HentSakstemaerTransformerTest.kt
@@ -13,7 +13,7 @@ internal class HentSakstemaerTransformerTest {
 
         val internal = external.toInternal()
 
-        internal.navn `should be equal to` external.navn
+        internal.navn.value `should be equal to` external.navn
         internal.kode `should be equal to` external.kode
         internal.journalposter.`should be empty`()
     }


### PR DESCRIPTION
Dette er en eksperimentell feature i Kotlin, man den har vært tilgjengelig i flere år. Jeg synes denne tilfører koden økt lesbarhet ved at man slipper å sende rundt Strings som parametere.

Det fungerer som minimale wrappere rundt felter som kun er strings. Denne wrappingen gir ingen overhead, og vil bli json-serialisert til samme verdi som om det var definert som en `String` direkte.

PB-606. minesaker-api - Sette opp graphQL-klient mot SAF