### PR TITLE
Inline-klassen Fodselsnummer gjorde slik at request-en fikk feil struktur

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/JournalposterRequest.kt
+++ b/src/main/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/JournalposterRequest.kt
@@ -14,7 +14,7 @@ class JournalposterRequest(override val variables: Map<String, Any>) : GraphQLRe
         fun create(ident: Fodselsnummer, temaSomSkalHentes: Sakstemakode): JournalposterRequest {
             return JournalposterRequest(
                 mapOf(
-                    "ident" to ident,
+                    "ident" to ident.value,
                     "temaetSomSkalHentes" to temaSomSkalHentes.toString(),
                 )
             )

--- a/src/main/kotlin/no/nav/personbruker/minesaker/api/saf/sakstemaer/SakstemaerRequest.kt
+++ b/src/main/kotlin/no/nav/personbruker/minesaker/api/saf/sakstemaer/SakstemaerRequest.kt
@@ -13,7 +13,7 @@ class SakstemaerRequest(override val variables: Map<String, Any>) : GraphQLReque
         fun create(ident: Fodselsnummer): SakstemaerRequest {
             return SakstemaerRequest(
                 mapOf(
-                    "ident" to ident
+                    "ident" to ident.value
                 )
             )
         }

--- a/src/test/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/JournalposterRequestTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/JournalposterRequestTest.kt
@@ -29,6 +29,7 @@ internal class JournalposterRequestTest {
         requestAsJson `should contain` identAsQueryVarible
         requestAsJson `should contain` sakstemaAsQueryVarible
         requestAsJson `should contain` expectedSakstemaAsInputVariable
+        requestAsJson `should contain` """"ident":"${dummyIdent.value}"""
     }
 
     @Test

--- a/src/test/kotlin/no/nav/personbruker/minesaker/api/saf/sakstemaer/SakstemaerRequestTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/minesaker/api/saf/sakstemaer/SakstemaerRequestTest.kt
@@ -23,6 +23,7 @@ internal class SakstemaerRequestTest {
         requestAsJson `should contain` expectedFields
         requestAsJson `should contain` identAsQueryVarible
         requestAsJson `should contain` expectedAllSakstemar
+        requestAsJson `should contain` """"ident":"${dummyIdent.value}"""
     }
 
 }


### PR DESCRIPTION
Etter inføringen av Fodselsnummer som inline-klasse ble GraphQL-variablene våre definert som: `"variables":{"ident":{"value":"123"}}` , altså med et value-ledd for mye. Har nå rettet til riktig format: `"variables":{"ident":"123"}`.

Dette var litt tricky å se, fordi SAFSelvbetjening ikke logget dette som en feil. De har nå justert sin logging. I tillegg har jeg ikke fått lagt til ordentlig feilhåndtering i mine-saker-api sin GraphQL-klient. Det fikser jeg i en ny oppgave.