### PR TITLE
Naiv implementasjon av å sette call-id

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/minesaker/api/saf/SafConsumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/minesaker/api/saf/SafConsumer.kt
@@ -27,7 +27,7 @@ class SafConsumer(
 
     private val log = LoggerFactory.getLogger(SafConsumer::class.java)
 
-    private val NavCallIdHeaderName = "Nav-Callid"
+    private val NavCallIdHeaderName = "Nav-Call-Id"
 
     suspend fun hentSakstemaer(request: SakstemaerRequest, accessToken: AccessToken): List<Sakstema> {
         val responseDto: GraphQLResponse<HentSakstemaer.Result> = sendQuery(request, accessToken)


### PR DESCRIPTION
Setter samme call-id-header som det `dittnav-legacy-api` gjør. Har for enkelhets skyld kun brukt en UUID som call-id, da jeg ikke tror det er noe bestemt krav for formatet.