### PR TITLE
Presenterer kun dokumentvarianter som gir mening å vise til sluttbruker

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/minesaker/api/common/exception/TransformationException.kt
+++ b/src/main/kotlin/no/nav/personbruker/minesaker/api/common/exception/TransformationException.kt
@@ -9,6 +9,7 @@ class TransformationException(
     constructor(message: String, type: ErrorType) : this(message, type, null)
 
     enum class ErrorType {
+        INVALID_STATE,
         MISSING_FIELD,
         UNKNOWN_VALUE,
     }

--- a/src/main/kotlin/no/nav/personbruker/minesaker/api/domain/Dokumentinfo.kt
+++ b/src/main/kotlin/no/nav/personbruker/minesaker/api/domain/Dokumentinfo.kt
@@ -5,5 +5,6 @@ data class Dokumentinfo(
     val dokumentInfoId: DokumentInfoId,
     val dokumenttype : Dokumenttype,
     val brukerHarTilgang: Boolean,
-    val eventuelleGrunnerTilManglendeTilgang : List<String>
+    val eventuelleGrunnerTilManglendeTilgang : List<String>,
+    val variant : Dokumentvariant
 )

--- a/src/main/kotlin/no/nav/personbruker/minesaker/api/domain/Dokumentvariant.kt
+++ b/src/main/kotlin/no/nav/personbruker/minesaker/api/domain/Dokumentvariant.kt
@@ -1,0 +1,6 @@
+package no.nav.personbruker.minesaker.api.domain
+
+enum class Dokumentvariant {
+    SLADDET,
+    ARKIV
+}

--- a/src/main/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/transformers/DokumentvariantTransformer.kt
+++ b/src/main/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/transformers/DokumentvariantTransformer.kt
@@ -1,0 +1,23 @@
+package no.nav.personbruker.minesaker.api.saf.journalposter.transformers
+
+import no.nav.dokument.saf.selvbetjening.generated.dto.HentJournalposter
+import no.nav.dokument.saf.selvbetjening.generated.dto.HentJournalposter.Variantformat.ARKIV
+import no.nav.dokument.saf.selvbetjening.generated.dto.HentJournalposter.Variantformat.SLADDET
+import no.nav.personbruker.minesaker.api.common.exception.TransformationException
+import no.nav.personbruker.minesaker.api.domain.*
+import org.slf4j.LoggerFactory
+
+private val log = LoggerFactory.getLogger(HentJournalposter.Variantformat::class.java)
+
+fun HentJournalposter.Variantformat.toInternal(): Dokumentvariant {
+    return when (this) {
+        ARKIV -> Dokumentvariant.ARKIV
+        SLADDET -> Dokumentvariant.SLADDET
+        else -> {
+            val msg = "Klarte ikke å konvertere dokumentvariant"
+            val exception = TransformationException(msg, TransformationException.ErrorType.INVALID_STATE)
+            exception.addContext("funnetVariantformat", this)
+            throw exception
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/personbruker/minesaker/api/domain/DokumentinfoObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/minesaker/api/domain/DokumentinfoObjectMother.kt
@@ -23,8 +23,8 @@ object DokumentinfoObjectMother {
         id,
         type,
         brukerHarTiltang,
-        grunnerTilIkkeTilgang
+        grunnerTilIkkeTilgang,
+        Dokumentvariant.SLADDET
     )
-
 
 }

--- a/src/test/kotlin/no/nav/personbruker/minesaker/api/domain/inlineClassesTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/minesaker/api/domain/inlineClassesTest.kt
@@ -1,7 +1,6 @@
 package no.nav.personbruker.minesaker.api.domain
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import no.nav.personbruker.minesaker.api.domain.*
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should contain`
 import org.junit.jupiter.api.Test
@@ -12,7 +11,14 @@ internal class inlineClassesTest {
 
     @Test
     fun `Inline klasser skal ikke generere noe overhead naar det serialiseres til JSON`() {
-        val dokumentinfo = Dokumentinfo(Tittel("Tittelen"), DokumentInfoId("filid"), Dokumenttype.HOVED,true, emptyList())
+        val dokumentinfo = Dokumentinfo(
+            Tittel("Tittelen"),
+            DokumentInfoId("filid"),
+            Dokumenttype.HOVED,
+            true,
+            emptyList(),
+            Dokumentvariant.SLADDET
+        )
 
         val dokumentInfoAsJson = objectMapper.writeValueAsString(dokumentinfo)
 
@@ -21,6 +27,7 @@ internal class inlineClassesTest {
         dokumentInfoAsJson `should contain` """"brukerHarTilgang":true"""
         dokumentInfoAsJson `should contain` """"eventuelleGrunnerTilManglendeTilgang":[]"""
         dokumentInfoAsJson `should contain` """"dokumenttype":"HOVED"""
+        dokumentInfoAsJson `should contain` """"variant":"SLADDET"""
     }
 
     @Test

--- a/src/test/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/objectmothers/DokumentInfoObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/objectmothers/DokumentInfoObjectMother.kt
@@ -36,14 +36,32 @@ object DokumentInfoObjectMother {
         return HentJournalposter.DokumentInfo("Dummytittel uten arkiverte varianger", dokumentInfoId, emptyList())
     }
 
-    fun giveMeDokumentMedFlereVarianter(): HentJournalposter.DokumentInfo {
+    fun giveMeDokumentMedSladdetOgArkivertVariant(): HentJournalposter.DokumentInfo {
         val varianter = listOf(
-            DokumentVariantObjectMother.giveMeOriginalVariant(),
-            DokumentVariantObjectMother.giveMeSladdetVariant()
+            DokumentVariantObjectMother.giveMeSladdetVariant(),
+            DokumentVariantObjectMother.giveMeArkivertVariant()
         )
         val dokumentInfoId = "dummyId005"
         val tittel = "Dummytittel medflere dokument varianter"
         return HentJournalposter.DokumentInfo(tittel, dokumentInfoId, varianter)
+    }
+
+    fun giveMeDokumentMedArkivertOgOriginalVariant(): HentJournalposter.DokumentInfo {
+        val varianter = listOf(
+            DokumentVariantObjectMother.giveMeOriginalVariant(),
+            DokumentVariantObjectMother.giveMeArkivertVariant()
+        )
+        val dokumentInfoId = "dummyId006"
+        val tittel = "Dummytittel medflere dokument varianter"
+        return HentJournalposter.DokumentInfo(tittel, dokumentInfoId, varianter)
+    }
+
+    fun giveMeDokumentMedKunOriginalVariant(): HentJournalposter.DokumentInfo {
+        val varianter = listOf(
+            DokumentVariantObjectMother.giveMeOriginalVariant(),
+        )
+        val dokumentInfoId = "dummyId007"
+        return HentJournalposter.DokumentInfo("Dummytittel med arkivert", dokumentInfoId, varianter)
     }
 
     fun giveMeTreGyldigeDokumenter(): List<HentJournalposter.DokumentInfo> {

--- a/src/test/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/transformers/DokumentinfoTransformerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/transformers/DokumentinfoTransformerTest.kt
@@ -2,8 +2,12 @@ package no.nav.personbruker.minesaker.api.saf.journalposter.transformers
 
 import no.nav.personbruker.minesaker.api.common.exception.TransformationException
 import no.nav.personbruker.minesaker.api.domain.Dokumenttype
+import no.nav.personbruker.minesaker.api.domain.Dokumentvariant
 import no.nav.personbruker.minesaker.api.saf.journalposter.objectmothers.DokumentInfoObjectMother
-import org.amshove.kluent.*
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.`should be instance of`
+import org.amshove.kluent.shouldNotBeEmpty
+import org.amshove.kluent.shouldNotBeNull
 import org.junit.jupiter.api.Test
 
 internal class DokumentinfoTransformerTest {
@@ -39,13 +43,35 @@ internal class DokumentinfoTransformerTest {
     }
 
     @Test
-    fun `Skal takle at et dokument har flere varianter, og plukke den forste varianten`() {
-        val externals = listOf(DokumentInfoObjectMother.giveMeDokumentMedFlereVarianter())
+    fun `Velg preferer alltid SLADDET-variant hvis den varianten finnes`() {
+        val externals = listOf(DokumentInfoObjectMother.giveMeDokumentMedSladdetOgArkivertVariant())
 
         val internals = externals.toInternal()
 
         internals.shouldNotBeNull()
         internals.size `should be equal to` 1
+        internals.first().variant `should be equal to` Dokumentvariant.SLADDET
+    }
+
+    @Test
+    fun `Hvis SLADDET-variant ikke finnes, velg ARKIVERT-variant`() {
+        val externals = listOf(DokumentInfoObjectMother.giveMeDokumentMedArkivertOgOriginalVariant())
+
+        val internals = externals.toInternal()
+
+        internals.shouldNotBeNull()
+        internals.size `should be equal to` 1
+        internals.first().variant `should be equal to` Dokumentvariant.ARKIV
+    }
+
+    @Test
+    fun `Ignorer andre varianter enn SLADDET og ARKIV`() {
+        val externals = listOf(DokumentInfoObjectMother.giveMeDokumentMedKunOriginalVariant())
+
+        val internals = externals.toInternal()
+
+        internals.shouldNotBeNull()
+        internals.size `should be equal to` 0
     }
 
     @Test

--- a/src/test/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/transformers/DokumentvariantTransformerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/transformers/DokumentvariantTransformerTest.kt
@@ -1,0 +1,31 @@
+package no.nav.personbruker.minesaker.api.saf.journalposter.transformers
+
+import no.nav.dokument.saf.selvbetjening.generated.dto.HentJournalposter
+import no.nav.personbruker.minesaker.api.common.exception.TransformationException
+import no.nav.personbruker.minesaker.api.domain.Dokumentvariant
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.`should be instance of`
+import org.junit.jupiter.api.Test
+
+internal class DokumentvariantTransformerTest {
+
+    @Test
+    fun `Skal kunne konvertere de to variantformatene som brukes`() {
+        HentJournalposter.Variantformat.ARKIV.toInternal() `should be equal to` Dokumentvariant.ARKIV
+        HentJournalposter.Variantformat.SLADDET.toInternal() `should be equal to` Dokumentvariant.SLADDET
+    }
+
+    @Test
+    fun `Skal kaste feil hvis det blir forsokt aa transformere et variantformat som ikke brukes`() {
+        val result = runCatching {
+            HentJournalposter.Variantformat.FULLVERSJON.toInternal()
+        }
+
+        result.isFailure `should be equal to` true
+        val exception = result.exceptionOrNull()
+        exception `should be instance of` TransformationException::class
+        exception as TransformationException
+        exception.type `should be equal to` TransformationException.ErrorType.INVALID_STATE
+    }
+
+}


### PR DESCRIPTION
SAF har lagt til flere dokumenttyper, og det er kun to av de som skal vises til sluttbruker. Det er alltid en av disse to variantene som presenteres for sluttbruker. Hvis ingen av de to variantene finnes vil ikke dokumentet vises, og dette blir logget.

PB-761. Filtrer bort dokumentvarianter som bruker ikke trenger å se