### PR TITLE
PB-762: La til et nytt endepunkt som viser pdf-er i en iframe

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,6 +82,7 @@ tasks {
         println("Setting default environment variables for running with DittNAV docker-compose")
 
         environment("SAF_API_URL", "http://localhost:8080/graphql")
+        environment("SAK_API_URL", "http://localhost:8091/person/mine-saker-api")
         environment("CORS_ALLOWED_ORIGINS", "localhost:9002")
 
         environment("OIDC_ISSUER", "http://localhost:9000")

--- a/src/main/kotlin/no/nav/personbruker/minesaker/api/config/Environment.kt
+++ b/src/main/kotlin/no/nav/personbruker/minesaker/api/config/Environment.kt
@@ -8,7 +8,8 @@ data class Environment(
     val safEndpoint: URL = URL(getEnvVar("SAF_API_URL")),
     val safClientId: String = getEnvVar("SAF_CLIENT_ID"),
     val clusterName: String = getEnvVar("NAIS_CLUSTER_NAME"),
-    val postLogoutUrl: String = getEnvVar("POST_LOGOUT_URL")
+    val postLogoutUrl: String = getEnvVar("POST_LOGOUT_URL"),
+    val sakApiUrl: String = getEnvVar("SAK_API_URL")
 )
 
 fun getEnvVar(varName: String, default: String? = null): String {

--- a/src/main/kotlin/no/nav/personbruker/minesaker/api/config/bootstrap.kt
+++ b/src/main/kotlin/no/nav/personbruker/minesaker/api/config/bootstrap.kt
@@ -47,7 +47,7 @@ fun Application.mainModule(appContext: ApplicationContext = ApplicationContext()
         healthApi(appContext.healthService)
 
         authenticate {
-            sakApi(appContext.sakService)
+            sakApi(appContext.sakService, appContext.environment.sakApiUrl)
             exchangeApi(appContext.tokendingsServiceWrapper, appContext.environment.clusterName)
         }
     }

--- a/src/main/kotlin/no/nav/personbruker/minesaker/api/sak/sakApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/minesaker/api/sak/sakApi.kt
@@ -20,7 +20,8 @@ val dokumentIdParameterName = "dokumentId"
 val journalpostIdParameterName = "journalpostId"
 
 fun Route.sakApi(
-    service: SakService
+    service: SakService,
+    sakApiUrl: String
 ) {
 
     val log = LoggerFactory.getLogger(SakService::class.java)
@@ -77,7 +78,7 @@ fun Route.sakApi(
     get("/dokument/{$journalpostIdParameterName}/{$dokumentIdParameterName}/index.html") {
         val journalpostId = call.parameters[journalpostIdParameterName]
         val dokumentId = call.parameters[dokumentIdParameterName]
-        val src = "https://mine-saker-api.dev.nav.no/person/mine-saker-api/dokument/$journalpostId/$dokumentId"
+        val src = "$sakApiUrl/dokument/$journalpostId/$dokumentId"
         call.respondHtml {
             attributes["style"] = "height: 100%;"
             body {


### PR DESCRIPTION
* La til et nytt endepunkt som viser pdf-er i en iframe
* Henter inn api url-en som en miljøvariabel

Dette gjøres fordi det er den enkleste måten å fikse UU-feil i siden som viser pdf-er. Nå får vi tilgang til å sette attributter i respondHtml.

PB-762: La til et nytt endepunkt som viser pdf-er i en iframe