### PR TITLE
SAF har sluttet å eksponere dokumentvarianter som uansett ikke skal vises til sluttbruker

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/transformers/DokumentInfoTransformer.kt
+++ b/src/main/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/transformers/DokumentInfoTransformer.kt
@@ -55,14 +55,13 @@ fun HentJournalposter.DokumentInfo.toInternal(
     externalVariant: HentJournalposter.Dokumentvariant,
     dokumenttype: Dokumenttype
 ): Dokumentinfo {
-    val brukerHarTilgang = externalVariant.brukerHarTilgang == true
     val eventuelleGrunnerTilManglendeTilgang =
-        plukkUtEventuelleGrunnerTilManglendeTilgang(brukerHarTilgang, externalVariant)
+        plukkUtEventuelleGrunnerTilManglendeTilgang(externalVariant.brukerHarTilgang, externalVariant)
     return Dokumentinfo(
         Tittel(tittel ?: "Uten tittel"),
         DokumentInfoId(dokumentInfoId),
         dokumenttype,
-        brukerHarTilgang,
+        externalVariant.brukerHarTilgang,
         eventuelleGrunnerTilManglendeTilgang,
         externalVariant.variantformat.toInternal()
     )

--- a/src/test/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/objectmothers/DokumentInfoObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/objectmothers/DokumentInfoObjectMother.kt
@@ -6,7 +6,6 @@ object DokumentInfoObjectMother {
 
     fun giveMeDokumentMedArkivertVariant(): HentJournalposter.DokumentInfo {
         val varianter = listOf(
-            DokumentVariantObjectMother.giveMeOriginalVariant(),
             DokumentVariantObjectMother.giveMeSladdetVariant(),
             DokumentVariantObjectMother.giveMeArkivertVariant()
         )
@@ -20,15 +19,6 @@ object DokumentInfoObjectMother {
         )
         val dokumentInfoId = "dummyId002"
         return HentJournalposter.DokumentInfo(null, dokumentInfoId, varianter)
-    }
-
-    fun giveMeDokumentMedArkivertVariantMenUtenAtTilgangErSpesifisert(): HentJournalposter.DokumentInfo {
-        val varianter = listOf(
-            DokumentVariantObjectMother.giveMeArkivertVariantUtenBrukerHarTilgangSatt()
-        )
-        val dokumentInfoId = "dummyId003"
-        val tittel = "Dummytittel med arkivert uten at tilgang er spesifisert"
-        return HentJournalposter.DokumentInfo(tittel, dokumentInfoId, varianter)
     }
 
     fun giveMeDokumentUtenNoenVarianter(): HentJournalposter.DokumentInfo {
@@ -46,24 +36,6 @@ object DokumentInfoObjectMother {
         return HentJournalposter.DokumentInfo(tittel, dokumentInfoId, varianter)
     }
 
-    fun giveMeDokumentMedArkivertOgOriginalVariant(): HentJournalposter.DokumentInfo {
-        val varianter = listOf(
-            DokumentVariantObjectMother.giveMeOriginalVariant(),
-            DokumentVariantObjectMother.giveMeArkivertVariant()
-        )
-        val dokumentInfoId = "dummyId006"
-        val tittel = "Dummytittel medflere dokument varianter"
-        return HentJournalposter.DokumentInfo(tittel, dokumentInfoId, varianter)
-    }
-
-    fun giveMeDokumentMedKunOriginalVariant(): HentJournalposter.DokumentInfo {
-        val varianter = listOf(
-            DokumentVariantObjectMother.giveMeOriginalVariant(),
-        )
-        val dokumentInfoId = "dummyId007"
-        return HentJournalposter.DokumentInfo("Dummytittel med arkivert", dokumentInfoId, varianter)
-    }
-
     fun giveMeTreGyldigeDokumenter(): List<HentJournalposter.DokumentInfo> {
         return listOf(
             giveMeDokument("Hveddok", "dummyId5", DokumentVariantObjectMother.giveMeArkivertVariant()),
@@ -75,7 +47,7 @@ object DokumentInfoObjectMother {
     private fun giveMeDokument(
         tittel: String = "Dummytittel gyldig dokument 11",
         dokumentInfoId: String = "dummyId011",
-        variant: HentJournalposter.Dokumentvariant = DokumentVariantObjectMother.giveMeOriginalVariant()
+        variant: HentJournalposter.Dokumentvariant = DokumentVariantObjectMother.giveMeArkivertVariant()
     ): HentJournalposter.DokumentInfo {
         return HentJournalposter.DokumentInfo(tittel, dokumentInfoId, listOf(variant))
     }

--- a/src/test/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/objectmothers/DokumentVariantObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/objectmothers/DokumentVariantObjectMother.kt
@@ -10,19 +10,6 @@ object DokumentVariantObjectMother {
         return HentJournalposter.Dokumentvariant(HentJournalposter.Variantformat.ARKIV, true, ingenFeilkode)
     }
 
-    fun giveMeArkivertVariantUtenDokumentInfoId(): HentJournalposter.Dokumentvariant {
-        return HentJournalposter.Dokumentvariant(HentJournalposter.Variantformat.ARKIV, true, ingenFeilkode)
-    }
-
-    fun giveMeArkivertVariantUtenBrukerHarTilgangSatt(): HentJournalposter.Dokumentvariant {
-        val feilkode = listOf("Skannet_dokument")
-        return HentJournalposter.Dokumentvariant(HentJournalposter.Variantformat.ARKIV, null, feilkode)
-    }
-
-    fun giveMeOriginalVariant(): HentJournalposter.Dokumentvariant {
-        return HentJournalposter.Dokumentvariant(HentJournalposter.Variantformat.ORIGINAL, true, ingenFeilkode)
-    }
-
     fun giveMeSladdetVariant(): HentJournalposter.Dokumentvariant {
         val feilkode = listOf("Skannet_dokument")
         return HentJournalposter.Dokumentvariant(HentJournalposter.Variantformat.SLADDET, true, feilkode)

--- a/src/test/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/transformers/DokumentinfoTransformerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/transformers/DokumentinfoTransformerTest.kt
@@ -54,47 +54,12 @@ internal class DokumentinfoTransformerTest {
     }
 
     @Test
-    fun `Hvis SLADDET-variant ikke finnes, velg ARKIVERT-variant`() {
-        val externals = listOf(DokumentInfoObjectMother.giveMeDokumentMedArkivertOgOriginalVariant())
-
-        val internals = externals.toInternal()
-
-        internals.shouldNotBeNull()
-        internals.size `should be equal to` 1
-        internals.first().variant `should be equal to` Dokumentvariant.ARKIV
-    }
-
-    @Test
-    fun `Ignorer andre varianter enn SLADDET og ARKIV`() {
-        val externals = listOf(DokumentInfoObjectMother.giveMeDokumentMedKunOriginalVariant())
-
-        val internals = externals.toInternal()
-
-        internals.shouldNotBeNull()
-        internals.size `should be equal to` 0
-    }
-
-    @Test
     fun `Skal takle at tittel ikke er tilgjengelig i SAF, return dummy tittel til sluttbruker`() {
         val externals = listOf(DokumentInfoObjectMother.giveMeDokumentMedArkivertVariantMenUtenTittel())
 
         val result = externals.toInternal()
 
         result[0].tittel.value `should be equal to` "Uten tittel"
-    }
-
-    @Test
-    fun `Skal sette tilgang til dokumentet som false hvis det ikke er spesifisert`() {
-        val externals = listOf(DokumentInfoObjectMother.giveMeDokumentMedArkivertVariantMenUtenAtTilgangErSpesifisert())
-        val expectedGrunnTilManglendeTilgang = externals[0].dokumentvarianter[0]?.code?.get(0)
-
-        val internals = externals.toInternal()
-
-        internals.shouldNotBeEmpty()
-        internals.size `should be equal to` 1
-        internals[0].brukerHarTilgang `should be equal to` false
-        internals[0].eventuelleGrunnerTilManglendeTilgang.size `should be equal to` 1
-        internals[0].eventuelleGrunnerTilManglendeTilgang[0] `should be equal to` expectedGrunnTilManglendeTilgang
     }
 
 }

--- a/src/test/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/transformers/DokumentvariantTransformerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/minesaker/api/saf/journalposter/transformers/DokumentvariantTransformerTest.kt
@@ -18,7 +18,7 @@ internal class DokumentvariantTransformerTest {
     @Test
     fun `Skal kaste feil hvis det blir forsokt aa transformere et variantformat som ikke brukes`() {
         val result = runCatching {
-            HentJournalposter.Variantformat.FULLVERSJON.toInternal()
+            HentJournalposter.Variantformat.__UNKNOWN_VALUE.toInternal()
         }
 
         result.isFailure `should be equal to` true


### PR DESCRIPTION
Oppdatert testene og testdata til å ikke lengre bruke dokumentvariantene som ikke lengre skal brukes.

Oppdatert ihht oppdateringer i SAF sitt schema.