### PR TITLE
Øker antall cachede tokenx tokens for å minske last mot tokendings.

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/minesaker/api/config/ApplicationContext.kt
+++ b/src/main/kotlin/no/nav/personbruker/minesaker/api/config/ApplicationContext.kt
@@ -15,7 +15,7 @@ class ApplicationContext {
     val httpClient = HttpClientBuilder.build()
     val healthService = HealthService(this)
 
-    val tokendingsService = TokendingsServiceBuilder.buildTokendingsService()
+    val tokendingsService = TokendingsServiceBuilder.buildTokendingsService(maxCachedEntries = 5000)
 
     val safTokendings = SafTokendings(tokendingsService, environment.safClientId)
     val digiSosTokendings = DigiSosTokendings(tokendingsService, environment.digiSosClientId)


### PR DESCRIPTION
I amplitude ser vi gjerne en peak rund 1700 unike brukere mot mine-saker-api, og vi hente 2 tokens per bruker (for digisos og saf).

Default cachestørrelse er 1000, og vi øker til 5000.