### PR TITLE
PB-932: Fjerne redirect til sykefravær for tema SYM/SYK

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/minesaker/api/config/innsynslenker.kt
+++ b/src/main/kotlin/no/nav/personbruker/minesaker/api/config/innsynslenker.kt
@@ -8,8 +8,6 @@ val innsynslenkerDev : Map<Sakstemakode, URL> = mapOf(
     Sakstemakode.DAG to URL("https://arbeid.dev.nav.no/arbeid/dagpenger/mine-dagpenger"),
     Sakstemakode.HJE to URL("https://hjelpemidler.dev.nav.no/hjelpemidler/dinehjelpemidler"),
     Sakstemakode.KOM to URL("https://www-q1.dev.nav.no/sosialhjelp/innsyn"),
-    Sakstemakode.SYM to URL("https://www-gcp.dev.nav.no/syk/sykefravaer"),
-    Sakstemakode.SYK to URL("https://www-gcp.dev.nav.no/syk/sykefravaer"),
 )
 
 val generellInnsynslenkeProd = URL("https://person.nav.no/mine-saker/tema/")

--- a/src/main/kotlin/no/nav/personbruker/minesaker/api/config/innsynslenker.kt
+++ b/src/main/kotlin/no/nav/personbruker/minesaker/api/config/innsynslenker.kt
@@ -15,6 +15,4 @@ val innsynslenkerProd : Map<Sakstemakode, URL> = mapOf(
     Sakstemakode.DAG to URL("https://www.nav.no/arbeid/dagpenger/mine-dagpenger"),
     Sakstemakode.HJE to URL("https://www.nav.no/hjelpemidler/dinehjelpemidler"),
     Sakstemakode.KOM to URL("https://www.nav.no/sosialhjelp/innsyn"),
-    Sakstemakode.SYM to URL("https://www.nav.no/syk/sykefravaer"),
-    Sakstemakode.SYK to URL("https://www.nav.no/syk/sykefravaer"),
 )


### PR DESCRIPTION
Fjernet redirect til innsynsløsningen sykefravaer for sakstema SYM og SYK.
Sakstema SYK/SYM skal bli lenket til egen innsynsløsningen på mine-saker nivå 2.